### PR TITLE
ci: Add API deploy on push on main

### DIFF
--- a/.github/workflows/update_data.yml
+++ b/.github/workflows/update_data.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 0 1 * *' 
   workflow_dispatch:
+  push:
+    branches:
+      - main
 
 jobs:
   update:


### PR DESCRIPTION
Add API deploy when pushing on the `main` branch